### PR TITLE
Fixing Exporter::AutoClean issue

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -5,6 +5,7 @@ all_from 'lib/Object/Container.pm';
 requires 'Carp';
 requires 'Class::Accessor::Fast';
 requires 'parent';
+requires 'B::Hooks::EndOfScope';
 
 recommends 'Exporter::AutoClean';
 test_requires 'Test::More' => '0.88';

--- a/lib/Object/Container.pm
+++ b/lib/Object/Container.pm
@@ -3,6 +3,7 @@ package Object::Container;
 use strict;
 use warnings;
 use parent qw(Class::Accessor::Fast);
+use B::Hooks::EndOfScope;
 use Carp;
 
 our $VERSION = '0.11';
@@ -36,13 +37,18 @@ do {
                     },
                 );
     
-                if (eval q[use Exporter::AutoClean]) {
+                if (eval q[require Exporter::AutoClean]) {
                     Exporter::AutoClean->export( $caller, %exports );
                 }
                 else {
                     while (my ($name, $fn) = each %exports) {
                         *{"${caller}::${name}"} = $fn;
                     }
+                    on_scope_end {
+                        for my $name (keys %exports) {
+                            delete ${ $caller . '::' }{ $name };
+                        }
+                    };
                     @EXPORTS = keys %exports;
                 }
             }

--- a/t/05_subclass_no_autoclean.t
+++ b/t/05_subclass_no_autoclean.t
@@ -14,7 +14,7 @@ isa_ok( $obj = obj('Object::Container'), 'Object::Container' );
 
 # obj->register == Foo::register because this is in no clean state
 is obj->can('register'), Foo->can('register'), 'obj->register == Foo::register ok';
-isnt obj->can('register'), Object::Container->can('register'), 'obj->register != Object::Container::register ok';;
+is obj->can('register'), Object::Container->can('register'), 'obj->register == Object::Container::register ok';;
 
 
 use Bar 'obj_clean';

--- a/t/no_clean/Exporter/AutoClean.pm
+++ b/t/no_clean/Exporter/AutoClean.pm
@@ -1,2 +1,1 @@
-die "Can't locale Exporter/AutoClean.pm";
-
+no Exporter::AutoClean;


### PR DESCRIPTION
Exporter::AutoCleanが有る場合でも無いと判断されてしまうようでしたので修正してみました。

ただ t/05_subclass_no_autoclean.t の17行目のテストがよくわからず、
isnt を is に変えてテスト成功させてしまいました。。すみません。
isnt obj->can('register'), Object::Container->can('register'), 'obj->register != Object::Container::register ok';;

perl 5.8.8 / 5.8.9 / 5.10.1 / 5.12.2 で Exporter::AutoCleanが有る場合と無い場合の
どちらも t/ 以下のテストは成功しました。
