### PR TITLE
Not touch args

### DIFF
--- a/lib/Object/Container.pm
+++ b/lib/Object/Container.pm
@@ -117,14 +117,13 @@ sub register {
     }
     elsif (ref $args eq 'HASH') {
         $class = $args->{class};
-        $args->{args} ||= [];
-        if (ref $args->{initializer} eq 'CODE') {
+        if (exists $args->{initializer} && ref $args->{initializer} eq 'CODE') {
             $initializer = $args->{initializer};
         }
         else {
             $initializer = sub {
                 $self->ensure_class_loaded($class);
-                $class->new(@{$args->{args}});
+                $class->new(@{exists $args->{args} ? $args->{args} : []});
             };
         }
 


### PR DESCRIPTION
Currently, when we pass locked hash as args, it will be an error "Attempt to access disallowed key in a restricted hash" (The message might depend on locking library though)
It'd be better the container library doesn't touch these.